### PR TITLE
Add networkType related stats for historical reasons with a warning on the privacy model

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,166 @@
       </dd>
     </dl>
   </section>
+  <section id="RTCIceServerStats-stat*">
+    <h3>
+      <dfn>RTCIceServerStats</dfn> dictionary non-standardized members
+    </h3>
+    <pre class="idl">partial dictionary RTCIceServerStats {
+       RTCNetworkType networkType;
+};</pre>
+    <dl data-link-for="RTCIceServerStats" data-dfn-for="RTCIceServerStats" class="dictionary-members">
+      <dt>
+        <dfn><code>networkType</code></dfn> of type <span class=
+        "idlMemberType"><a>RTCNetworkType</a></span>
+      </dt>
+      <dd>
+        <div class="warning">
+          This member is included in this document for historical reasons.
+          Additional work is needed to reach consensus on the privacy model.
+        </div>
+        <p>
+          Represents the type of network interface used.
+        </p>
+      </dd>
+    </dl>
+  </section>
+  <section id="RTCIceCandidateStats-stat*">
+    <h3>
+      <dfn>RTCIceCandidateStats</dfn> dictionary non-standardized members
+    </h3>
+    <pre class="idl">partial dictionary RTCIceCandidateStats {
+       RTCNetworkType networkType;
+};</pre>
+    <dl data-link-for="RTCIceCandidateStats" data-dfn-for="RTCIceCandidateStats" class="dictionary-members">
+      <dt>
+        <dfn><code>networkType</code></dfn> of type <span class=
+        "idlMemberType"><a>RTCNetworkType</a></span>
+      </dt>
+      <dd>
+        <div class="warning">
+          This member is included in this document for historical reasons.
+          Additional work is needed to reach consensus on the privacy model.
+        </div>
+        <p>
+          Represents the type of network interface used by the base of a local candidate
+          (the address the ICE agent sends from). Only present for local candidates; it's
+          not possible to know what type of network interface a remote candidate is using.
+        </p>
+        <div class="note">
+          This stat only tells you about the network interface used by the first "hop";
+          it's possible that a connection will be bottlenecked by another type of network.
+          For example, when using Wi-Fi tethering, the <code>networkType</code> of the
+          relevant candidate would be <code>"wifi"</code>, even when the next hop is over a
+          cellular connection.
+        </div>
+        <p class="fingerprint">
+          This reveals information that would otherwise not be available to web pages,
+          which increases the fingerprint surface.
+        </p>
+      </dd>
+    </dl>
+  </section>
+  <section>
+    <h3>
+      <dfn>RTCNetworkType</dfn> enum
+    </h3>
+    <div class="warning">
+      This enum is included in this document for historical reasons.
+      Additional work is needed to reach consensus on the privacy model.
+    </div>
+    <div>
+      <pre class="idl">
+enum RTCNetworkType {
+    "bluetooth",
+    "cellular",
+    "ethernet",
+    "wifi",
+    "wimax",
+    "vpn",
+    "unknown"
+};</pre>
+        <table data-link-for="RTCNetworkType" data-dfn-for="RTCNetworkType" class="simple">
+          <tbody>
+            <tr>
+              <th colspan="2">
+                Enumeration description
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>bluetooth</code></dfn>
+              </td>
+              <td>
+                <p>
+                  A Bluetooth connection.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>cellular</code></dfn>
+              </td>
+              <td>
+                <p>
+                  A cellular connection (e.g., EDGE, HSPA, LTE, etc.).
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>ethernet</code></dfn>
+              </td>
+              <td>
+                <p>
+                  An Ethernet connection.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>wifi</code></dfn>
+              </td>
+              <td>
+                <p>
+                  A Wi-Fi connection.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>wimax</code></dfn>
+              </td>
+              <td>
+                <p>
+                  A WiMAX connection.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>vpn</code></dfn>
+              </td>
+              <td>
+                <p>
+                  The connection runs over a VPN. The underlying network type is not available.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn><code>unknown</code></dfn>
+              </td>
+              <td>
+                <p>
+                  The user agent is unable or unwilling to identify the underlying connection
+                  technology.
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 </body>
 
 </html>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-provisional-stats/pull/18.html" title="Last updated on Dec 12, 2019, 2:02 PM UTC (b183f16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-provisional-stats/18/9e682de...youennf:b183f16.html" title="Last updated on Dec 12, 2019, 2:02 PM UTC (b183f16)">Diff</a>