### PR TITLE
jitterBufferTargetDelay

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
           sample is emitted by the jitter buffer. The added target is the target
           delay, in seconds, at the time that the sample was emitted from the
           jitter buffer. To get the average target delay, divide by
-          jitterBufferEmittedCount.
+          <code>jitterBufferEmittedCount</code>.
         </p>
       </dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,8 @@
           This value is increased by the target jitter buffer delay every time a
           sample is emitted by the jitter buffer. The added target is the target
           delay, in seconds, at the time that the sample was emitted from the
-          jitter buffer.
+          jitter buffer. To get the average target delay, divide by
+          jitterBufferEmittedCount.
         </p>
       </dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
     </h3>
     <pre class="idl">partial dictionary RTCInboundRtpStreamStats {
       DOMString  contentType;
+      double jitterBufferTargetDelay;
 };</pre>
     <dl data-link-for="RTCInboundRtpStreamStats" data-dfn-for="RTCInboundRtpStreamStats" class=
     "dictionary-members">
@@ -139,6 +140,17 @@
           is invalid or no last packet of a key frame has been received yet,
           <code>contentType</code> is missing.
         </p>
+      </dd>
+      <dt>
+        <dfn><code>jitterBufferTargetDelay</code></dfn> of type
+        <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-double">double</a></span>
+      </dt>
+      <dd>
+        <p>
+          This value is increased by the target jitter buffer delay every time a
+          sample is emitted by the jitter buffer. The added target is the target
+          delay, in seconds, at the time that the sample was emitted from the
+          jitter buffer.
         </p>
       </dd>
     </dl>


### PR DESCRIPTION
Fixes #19:

> In the webrtc.org's implementation of the audio jitter buffer, the jitter buffer has an actual delay ([jitterBufferDelay](https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay)) and a target delay.
> 
> An implementation does not need to have a target, but for testing it is useful to be able to compare the actual value with the target value. This tells you something about how well samples get accelerated or decelerated.
> 
> Because this is a bit implementation-specific, and tells you more about the implementation's ability to deliver what it wants to deliver rather than direct measurements of achieved quality, this is added to the provisional stats spec for further evaluation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-provisional-stats/pull/20.html" title="Last updated on Feb 15, 2021, 8:01 AM UTC (54498bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-provisional-stats/20/43c2a41...henbos:54498bf.html" title="Last updated on Feb 15, 2021, 8:01 AM UTC (54498bf)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-provisional-stats/pull/20.html" title="Last updated on Jun 2, 2022, 9:10 AM UTC (dfa3158)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-provisional-stats/20/4d6eaf2...henbos:dfa3158.html" title="Last updated on Jun 2, 2022, 9:10 AM UTC (dfa3158)">Diff</a>