### PR TITLE
Remove jitterBufferTargetDelay (after having been added to the main spec)

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@
       <dfn>RTCInboundRtpStreamStats</dfn> dictionary non-standardized members
     </h3>
     <pre class="idl">partial dictionary RTCInboundRtpStreamStats {
-      double               jitterBufferTargetDelay;
+      DOMString            contentType;
       unsigned long        frameBitDepth;
       boolean              voiceActivityFlag;
       double               averageRtcpInterval;

--- a/index.html
+++ b/index.html
@@ -89,7 +89,6 @@
     </h3>
     <pre class="idl">partial dictionary RTCInboundRtpStreamStats {
       DOMString  contentType;
-      double jitterBufferTargetDelay;
 };</pre>
     <dl data-link-for="RTCInboundRtpStreamStats" data-dfn-for="RTCInboundRtpStreamStats" class=
     "dictionary-members">
@@ -108,19 +107,6 @@
           all other cases, such as if the header extension is missing, its value
           is invalid or no last packet of a key frame has been received yet,
           <code>contentType</code> is missing.
-        </p>
-      </dd>
-      <dt>
-        <dfn><code>jitterBufferTargetDelay</code></dfn> of type
-        <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-double">double</a></span>
-      </dt>
-      <dd>
-        <p>
-          This value is increased by the target jitter buffer delay every time a
-          sample is emitted by the jitter buffer. The added target is the target
-          delay, in seconds, at the time that the sample was emitted from the
-          jitter buffer. To get the average target delay, divide by
-          <code>jitterBufferEmittedCount</code>.
         </p>
       </dd>
     </dl>


### PR DESCRIPTION
Fixes #24.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/webrtc-provisional-stats/pull/25.html" title="Last updated on Jun 14, 2022, 1:36 PM UTC (97f7e6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-provisional-stats/25/e9410b2...henbos:97f7e6a.html" title="Last updated on Jun 14, 2022, 1:36 PM UTC (97f7e6a)">Diff</a>