### PR TITLE
Remove rtxSsrc which was moved to webrtc-stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,6 @@
       <dfn>RTCOutboundRtpStreamStats</dfn> dictionary non-standardized members
     </h3>
     <pre class="idl">partial dictionary RTCOutboundRtpStreamStats {
-      unsigned long         rtxSsrc;
       DOMString             contentType;
       DOMHighResTimeStamp   lastPacketSentTimestamp;
       unsigned long         packetsDiscardedOnSend;
@@ -296,19 +295,6 @@
 };</pre>
     <dl data-link-for="RTCOutboundRtpStreamStats" data-dfn-for="RTCOutboundRtpStreamStats" class=
     "dictionary-members">
-      <dt>
-        <dfn>rtxSsrc</dfn> of type <span class="idlMemberType">unsigned long</span>
-      </dt>
-      <dd>
-        <p>
-          If RTX is negotiated as a separate stream, this is the <a>SSRC</a> of the
-          RTX stream that is associated with this stream's {{RTCRtpStreamStats/ssrc}}.
-          If RTX is not negotiated, this value is not present. Whether or not RTX is
-          negotiated, retransmissions are accounted for in the
-          {{RTCSentRtpStreamStats/bytesSent}} and
-          {{RTCOutboundRtpStreamStats/retransmittedBytesSent}} stats of this object.
-        </p>
-      </dd>
       <dt>
         <dfn><code>contentType</code></dfn> of type
         <span class="idlMemberType"><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></span>


### PR DESCRIPTION
moved in https://github.com/w3c/webrtc-stats/pull/765


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-provisional-stats/pull/42.html" title="Last updated on Aug 4, 2023, 8:53 AM UTC (5733ff8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-provisional-stats/42/4585afe...fippo:5733ff8.html" title="Last updated on Aug 4, 2023, 8:53 AM UTC (5733ff8)">Diff</a>